### PR TITLE
removed shadowThemeOnly which is not supported in flutter version v2

### DIFF
--- a/lib/src/date_picker.dart
+++ b/lib/src/date_picker.dart
@@ -106,7 +106,7 @@ class DatePicker {
         onCancel: onCancel,
         onChange: onChange,
         onConfirm: onConfirm,
-        theme: Theme.of(context, shadowThemeOnly: true),
+        theme: Theme.of(context),
         barrierLabel:
             MaterialLocalizations.of(context).modalBarrierDismissLabel,
         minuteDivider: minuteDivider,


### PR DESCRIPTION
Issue fixed:
https://github.com/dylanwuzh/flutter-cupertino-date-picker/issues/139